### PR TITLE
Update bracket-matcher-view.coffee

### DIFF
--- a/lib/bracket-matcher-view.coffee
+++ b/lib/bracket-matcher-view.coffee
@@ -3,15 +3,8 @@ _ = require 'underscore-plus'
 {Range} = require 'atom'
 TagFinder = require './tag-finder'
 
-startPairMatches =
-  '(': ')'
-  '[': ']'
-  '{': '}'
 
-endPairMatches =
-  ')': '('
-  ']': '['
-  '}': '{'
+
 
 pairRegexes = {}
 for startPair, endPair of startPairMatches


### PR DESCRIPTION
Trying to turn off automatically closing ", {, ( without disabling matching bracket highlight
